### PR TITLE
Add content loading util and preview page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ A web-based social deduction word game built with Next.js 14, Tailwind CSS, shad
    ```bash
    npm run dev
    ```
+4. **Preview content**
+   - Visit `/dev/content-editor` to browse the seeded category boards.
 
 ## Project Structure
 

--- a/src/app/dev/content-editor/page.tsx
+++ b/src/app/dev/content-editor/page.tsx
@@ -1,11 +1,26 @@
 'use client';
-import React from 'react';
+import React, { useState } from 'react';
+import ModeToggle from '../../../components/ModeToggle';
+import BoardGrid from '../../../components/BoardGrid';
+import { loadBoards } from '../../../lib/content';
+import { ContentMode } from '../../../lib/models';
 
 export default function ContentEditorPage() {
+  const [mode, setMode] = useState<ContentMode>('FAMILY');
+  const boards = loadBoards(mode);
+  const first = boards[0];
+
   return (
-    <main className="p-4 space-y-2">
+    <main className="p-4 space-y-4">
       <h1 className="text-xl">Content Editor</h1>
-      <p>Dev-only category editor placeholder.</p>
+      <ModeToggle mode={mode} onChange={setMode} />
+      {first && (
+        <div className="space-y-2">
+          <h2 className="font-semibold">{first.title}</h2>
+          <BoardGrid board={first} />
+        </div>
+      )}
+      <p className="text-sm text-gray-500">Total boards: {boards.length}</p>
     </main>
   );
 }

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,0 +1,12 @@
+import boards from '../data/categories.seed.json';
+import { CategoryBoard, ContentMode } from './models';
+
+export function loadBoards(mode?: ContentMode): CategoryBoard[] {
+  const list = boards as CategoryBoard[];
+  return mode ? list.filter((b) => b.mode === mode) : list;
+}
+
+export function getRandomBoard(mode: ContentMode): CategoryBoard {
+  const list = loadBoards(mode);
+  return list[Math.floor(Math.random() * list.length)];
+}


### PR DESCRIPTION
## Summary
- add helper to load seeded category boards and pick one at random
- preview the first board in `/dev/content-editor` with a mode toggle
- mention preview route in documentation

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689568aa9ba08329ac9a2e2f629f6418